### PR TITLE
BER-229 set authorization token and extra params on GET media requests.

### DIFF
--- a/MatrixSDK/Data/MXRoom.m
+++ b/MatrixSDK/Data/MXRoom.m
@@ -17,6 +17,9 @@
  limitations under the License.
  */
 
+// NOTICE that the present file has been modified by Nedap Healthcare.
+// Copyright (c) 2023 N.V. Nederlandsche Apparatenfabriek (Nedap). All rights reserved.
+
 #import "MXRoom.h"
 
 #import "MXSession.h"
@@ -45,6 +48,9 @@ NSString *const kMXRoomDidFlushDataNotification = @"kMXRoomDidFlushDataNotificat
 NSString *const kMXRoomInitialSyncNotification = @"kMXRoomInitialSyncNotification";
 NSInteger const kMXRoomAlreadyJoinedErrorCode = 9001;
 NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
+// Modified by Nedap. The size of thumbnail we request from the server is needed to store the downloaded image in cache (BER-229)
+static const int kThumbnailWidth = 320;
+static const int kThumbnailHeight = 240;
 
 #warning File has not been annotated with nullability, see MX_ASSUME_MISSING_NULLABILITY_BEGIN
 
@@ -69,7 +75,7 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
     BOOL needToLoadLiveTimeline;
 
     /**
-     FIFO queue of objects waiting for [self liveTimeline:]. 
+     FIFO queue of objects waiting for [self liveTimeline:].
      */
     NSMutableArray<void (^)(id<MXEventTimeline>)> *pendingLiveTimelineRequesters;
 
@@ -1193,7 +1199,9 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
                 }
 
                 // Copy the cached image to the actual cacheFile path
-                NSString *actualCacheFilePath = [MXMediaManager cachePathForMatrixContentURI:url andType:mimetype inFolder:self.roomId];
+                // Modified by Nedap. The size of thumbnail we request from the server is needed to store the downloaded image in cache (BER-229)
+                NSString *actualCacheFilePath = [MXMediaManager thumbnailCachePathForMatrixContentURI:url andType:mimetype inFolder:self.roomId toFitViewSize:CGSizeMake(kThumbnailWidth, kThumbnailHeight) withMethod:MXThumbnailingMethodScale];
+                                
                 NSError *error;
                 [[NSFileManager defaultManager] copyItemAtPath:cacheFilePath toPath:actualCacheFilePath error:&error];
 
@@ -3254,7 +3262,7 @@ NSInteger const kMXRoomInvalidInviteSenderErrorCode = 9002;
 
                     // Here we find the right event to acknowledge, and it is posterior to the current position (if any).
                     break;
-                }                
+                }
             }
         }
     }

--- a/MatrixSDK/MXSession.m
+++ b/MatrixSDK/MXSession.m
@@ -17,6 +17,9 @@
  limitations under the License.
  */
 
+// NOTICE that the present file has been modified by Nedap Healthcare.
+// Copyright (c) 2023 N.V. Nederlandsche Apparatenfabriek (Nedap). All rights reserved.
+
 #import "MXSession.h"
 #import "MatrixSDK.h"
 
@@ -231,7 +234,8 @@ typedef void (^MXOnResumeDone)(void);
     {
         matrixRestClient = mxRestClient;
         _threePidAddManager = [[MX3PidAddManager alloc] initWithMatrixSession:self];
-        mediaManager = [[MXMediaManager alloc] initWithHomeServer:matrixRestClient.homeserver];
+        // Modified by Nedap. Pass access token to load the image (BER-229)
+        mediaManager = [[MXMediaManager alloc] initWithHomeServer:matrixRestClient.homeserver andAccessToken:matrixRestClient.credentials.accessToken];
         rooms = [NSMutableDictionary dictionary];
         roomSummaries = [NSMutableDictionary dictionary];
         _roomSummaryUpdateDelegate = [MXRoomSummaryUpdater roomSummaryUpdaterForSession:self];
@@ -4658,8 +4662,8 @@ typedef void (^MXOnResumeDone)(void);
                  failure(error);
              }
          }];
-    } 
-    else 
+    }
+    else
     {
         if (success)
         {

--- a/MatrixSDK/Utils/Media/MXMediaLoader.h
+++ b/MatrixSDK/Utils/Media/MXMediaLoader.h
@@ -15,6 +15,9 @@
  limitations under the License.
  */
 
+// NOTICE that the present file has been modified by Nedap Healthcare.
+// Copyright (c) 2023 N.V. Nederlandsche Apparatenfabriek (Nedap). All rights reserved.
+
 #import "TargetConditionals.h"
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -108,7 +111,7 @@ extern NSString *const kMXMediaUploadIdPrefix;
  `MXMediaLoader` defines a class to download/upload media. It provides progress information during the operation.
  */
 @interface MXMediaLoader : NSObject <NSURLConnectionDataDelegate, NSURLConnectionDelegate>
-{    
+{
     blockMXMediaLoader_onSuccess onSuccess;
     blockMXMediaLoader_onError onError;
     
@@ -177,31 +180,44 @@ extern NSString *const kMXMediaUploadIdPrefix;
 @property (readonly) CGFloat uploadInitialRange;
 @property (readonly) CGFloat uploadRange;
 
+// Modified by Nedap. Init with access token to set the authorization token on media requests (BER-229)
+/**
+ Init 'MXMediaLoader' instance with the access token.
+ 
+ @param accessToken the server access token.
+ */
+- (id)initWithAccessToken:(NSString*)accessToken;
+
 /**
  Cancel the operation.
  */
 - (void)cancel;
 
+// Modified by Nedap. Pass extra params to the url query in order to download media (BER-229)
 /**
  Download data from the provided URL.
  
  @param url remote media url.
  @param downloadId the download identifier.
+ @param params extra key-value pair used to build the url with parameters if any.
  @param filePath output file in which downloaded media must be saved.
  @param success a block called when the operation succeeds.
  @param failure a block called when the operation fails.
  */
 - (void)downloadMediaFromURL:(NSString *)url
               withIdentifier:(NSString *)downloadId
+                  parameters:(NSDictionary *)params
            andSaveAtFilePath:(NSString *)filePath
                      success:(blockMXMediaLoader_onSuccess)success
                      failure:(blockMXMediaLoader_onError)failure;
 
+// Modified by Nedap. Pass extra params to the url query in order to download media (BER-229)
 /**
  Download data from the provided URL with optionally a dictionary of data to post.
  
  @param url remote media url.
  @param data (optional) a dictionary of data sent as a JSON object in the message body.
+ @param params extra key-value pair used to build the url with parameters if any.
  @param downloadId the download identifier.
  @param filePath output file in which downloaded media must be saved.
  @param success a block called when the operation succeeds.
@@ -209,6 +225,7 @@ extern NSString *const kMXMediaUploadIdPrefix;
  */
 - (void)downloadMediaFromURL:(NSString *)url
                     withData:(NSDictionary *)data
+                  parameters:(NSDictionary *)params
                   identifier:(NSString *)downloadId
            andSaveAtFilePath:(NSString *)filePath
                      success:(blockMXMediaLoader_onSuccess)success

--- a/MatrixSDK/Utils/Media/MXMediaManager.h
+++ b/MatrixSDK/Utils/Media/MXMediaManager.h
@@ -45,14 +45,16 @@ extern NSString *const kMXMediaManagerDefaultCacheFolder;
  */
 @interface MXMediaManager : NSObject
 
+// Modified by Nedap. Init with access token to pass the authorization token to media loader (BER-229)
 /**
  Create an instance based on a homeserver url. This homeserver URL is required to resolve
  the Matrix Content URI (in the form of "mxc://...").
  
  @param homeserverURL the homeserver URL.
+ @param accessToken the server access token.
  @return a MXMediaManager instance.
  */
-- (id)initWithHomeServer:(NSString *)homeserverURL;
+- (id)initWithHomeServer:(NSString *)homeserverURL andAccessToken:(NSString*)accessToken;
 
 /**
  The homeserver URL.
@@ -123,7 +125,7 @@ extern NSString *const kMXMediaManagerDefaultCacheFolder;
  @return Image (if any).
  */
 #if TARGET_OS_IPHONE
-+ (UIImage*)loadPictureFromFilePath:(NSString*)filePath; 
++ (UIImage*)loadPictureFromFilePath:(NSString*)filePath;
 #elif TARGET_OS_OSX
 + (NSImage*)loadPictureFromFilePath:(NSString*)filePath;
 #endif
@@ -210,10 +212,12 @@ extern NSString *const kMXMediaManagerDefaultCacheFolder;
                                       toFitViewSize:(CGSize)viewSize
                                          withMethod:(MXThumbnailingMethod)thumbnailingMethod;
 
+// Modified by Nedap. Pass extra params to the url query in order to download media (BER-229)
 /**
  Download data from the provided Matrix Content (MXC) URI (in the form of "mxc://...").
  
  @param mxContentURI the Matrix Content URI.
+ @param params extra key-value pair used to build the url with parameters if any.
  @param mimeType the media mime type (may be nil).
  @param folder the cache folder to use (may be nil). kMXMediaManagerDefaultCacheFolder is used by default.
  @param success a block called when the download succeeds. This block gets the path of the resulting file.
@@ -221,28 +225,34 @@ extern NSString *const kMXMediaManagerDefaultCacheFolder;
  @return a media loader in order to let the user cancel this action.
  */
 - (MXMediaLoader*)downloadMediaFromMatrixContentURI:(NSString *)mxContentURI
+                                          addParams:(NSDictionary *)params
                                            withType:(NSString *)mimeType
                                            inFolder:(NSString *)folder
                                             success:(void (^)(NSString *outputFilePath))success
                                             failure:(void (^)(NSError *error))failure;
 
+// Modified by Nedap. Pass extra params to the url query in order to download media (BER-229)
 /**
  Download data from the provided Matrix Content (MXC) URI (in the form of "mxc://...").
  
  @param mxContentURI the Matrix Content URI.
+ @param params extra key-value pair used to build the url with parameters if any.
  @param mimeType the media mime type (may be nil).
  @param folder the cache folder to use (may be nil). kMXMediaManagerDefaultCacheFolder is used by default.
  @return a media loader in order to let the user cancel this action.
  */
 - (MXMediaLoader*)downloadMediaFromMatrixContentURI:(NSString *)mxContentURI
+                                          addParams:(NSDictionary *)params
                                            withType:(NSString *)mimeType
                                            inFolder:(NSString *)folder;
 
+// Modified by Nedap. Pass extra params to the url query in order to download media (BER-229)
 /**
  Download thumbnail data from the provided Matrix Content (MXC) URI (in the form of "mxc://...")
  to fit a specific view size.
  
  @param mxContentURI the Matrix Content URI.
+ @param params extra key-value pair used to build the url with parameters if any.
  @param mimeType the media mime type (may be nil).
  @param folder the cache folder to use (may be nil). kMXMediaManagerDefaultCacheFolder is used by default.
  @param viewSize the size in points of the view in which the thumbnail will be displayed, it will be converted
@@ -253,6 +263,7 @@ extern NSString *const kMXMediaManagerDefaultCacheFolder;
  @return a media loader in order to let the user cancel this action.
  */
 - (MXMediaLoader*)downloadThumbnailFromMatrixContentURI:(NSString *)mxContentURI
+                                              addParams:(NSDictionary *)params
                                                withType:(NSString *)mimeType
                                                inFolder:(NSString *)folder
                                           toFitViewSize:(CGSize)viewSize

--- a/MatrixSDKTests/MXSelfSignedHomeserverTests.m
+++ b/MatrixSDKTests/MXSelfSignedHomeserverTests.m
@@ -14,6 +14,9 @@
  limitations under the License.
  */
 
+// NOTICE that the present file has been modified by Nedap Healthcare.
+// Copyright (c) 2023 N.V. Nederlandsche Apparatenfabriek (Nedap). All rights reserved.
+
 #import <XCTest/XCTest.h>
 
 #import "MatrixSDKTestsData.h"
@@ -214,15 +217,17 @@
                     XCTAssert(contentURL);
 
                     // Download back the image
+                    // Modified by Nedap. Pass extra params to the url query in order to download media (BER-229)
                     [mxSession.mediaManager downloadMediaFromMatrixContentURI:contentURL
+                                                                    addParams:@{@"event_id":event.eventId}
                                                                      withType:nil
                                                                      inFolder:nil
                                                                       success:^(NSString *outputFilePath) {
-                                                                          [expectation fulfill];
-                                                                      } failure:^(NSError *error) {
-                                                                          XCTFail(@"The request should not fail - NSError: %@", error);
-                                                                          [expectation fulfill];
-                                                                      }];
+                        [expectation fulfill];
+                    } failure:^(NSError *error) {
+                        XCTFail(@"The request should not fail - NSError: %@", error);
+                        [expectation fulfill];
+                    }];
                 }];
             }];
 
@@ -283,7 +288,8 @@
                     NSString *contentURL = event.content[@"url"];
                     XCTAssert(contentURL);
                     
-                    MXMediaManager *mediaManager = [[MXMediaManager alloc] initWithHomeServer:mxSession.matrixRestClient.homeserver];
+                    // Modified by Nedap. Init with access token to set the authorization token on media requests (BER-229)
+                    MXMediaManager *mediaManager = [[MXMediaManager alloc] initWithHomeServer:mxSession.matrixRestClient.homeserver andAccessToken:mxSession.matrixRestClient.credentials.accessToken];
                     XCTAssert(mediaManager);
                     
                     [mxSession close];
@@ -292,16 +298,17 @@
                     [[MXAllowedCertificates sharedInstance] reset];
 
                     // Then, try to download back the image
+                    // Modified by Nedap. Pass extra params to the url query in order to download media (BER-229)
                     [mediaManager downloadMediaFromMatrixContentURI:contentURL
-                                                                     withType:nil
-                                                                     inFolder:nil
-                                                                      success:^(NSString *outputFilePath) {
-                                                                          XCTFail(@"The operation must fail because the self-signed certficate was not trusted (anymore)");
-                                                                          [expectation fulfill];
-                                                                      } failure:^(NSError *error) {
-                                                                          [expectation fulfill];
-                                                                      }];
-
+                                                          addParams:@{@"event_id": event.eventId}
+                                                           withType:nil
+                                                           inFolder:nil
+                                                            success:^(NSString *outputFilePath) {
+                        XCTFail(@"The operation must fail because the self-signed certficate was not trusted (anymore)");
+                        [expectation fulfill];
+                    } failure:^(NSError *error) {
+                        [expectation fulfill];
+                    }];
                 }];
             }];
 


### PR DESCRIPTION
**Context**
Why do we want/need it? - to make GET media requests work

**Relevant issues**
Closes [BER-229](https://github.com/nedap/berichten-ios/issues/229)

**Changes**
- sets authorization token and extra params on all GET media requests