### PR TITLE
BER-336: Handle all `CryptoStoreError` cases by deleting previous data and trying again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes specific for Berichten Matrix SDK will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.1.3] - Unreleased
+##### Added
+
+##### Fixed
+- BER-336: Handle all `CryptoStoreError` cases by deleting previous data and trying again
+
+##### Changed
+
 ## [v0.1.2] - 12/03/2024
 ##### Added
 - BER-332: Merge upstream MatrixSDK v0.27.6. 
@@ -29,6 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ---
 
+[v0.1.3]: https://github.com/nedap/matrix-ios-sdk/compare/nedap/0.1.2...nedap/0.1.3
 [v0.1.2]: https://github.com/nedap/matrix-ios-sdk/compare/nedap/0.1.1...nedap/0.1.2
 [v0.1.1]: https://github.com/nedap/matrix-ios-sdk/compare/nedap/0.1.0...nedap/0.1.1
 [v0.1.0]: https://github.com/nedap/matrix-ios-sdk/compare/nedap/0.1.0...nedap/0.1.0


### PR DESCRIPTION
**Context**
> Why do we want/need it?
- To ensure a smooth login process for our users. 

**Relevant issues**
- Closes https://github.com/nedap/berichten-ios/issues/336

**Changes**
> What does it do?
> In summary, what changes are made to the code?
- Unfortunately, there wasn't a way to reproduce this bug, it could only be hardcoded. However, the user who encountered the bug, reported that the following screen with that error message is now shown, before getting stuck in the login view. 

![IMG_4574 (1)](https://github.com/nedap/matrix-ios-sdk/assets/145033489/190cc15a-e1ce-4168-b84e-f0317c9ad9f1)

- So, I looked into the code, and that message is displayed in two cases:
1. When DB upgrade is initiated (meaning, there is already a realm file and the app tries to obtain the Realm instance, but it fails twice. If this case happens, the sdk suggests that a user logout should fix it.) I couldn't reproduce this use case though and I don't think this is the issue since the user didn't install the app over an old version to trigger Realm migration, he did a fresh install.
2. When crypto store cannot be opened. There was already a handling for this case, but only for `CryptoStore` error, more specific when `MismatchedAccountError` is triggered. I extended it to cover the entire `CryptoStoreError` cases. With hardcoding, I could only catch `OpenStore` error, but by looking at the cases defined in the [matrix-rust-sdk](https://matrix-org.github.io/matrix-rust-sdk/matrix_sdk_crypto/store/enum.CryptoStoreError.html) I found it's safe to delete the previous data and try again for all `CryptoStoreError` cases because if opening the the store doesn't work, it will throw the error anyway, so the user gets stuck with that alert. 