### PR TITLE
BER-541: Handle `OpenStore` and `CryptoStore` errors by deleting previous data and retrying the crypto store opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes specific for Berichten Matrix SDK will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.1.] - 06/11/2024
+##### Added
+
+##### Fixed
+- BER-541: Handle `OpenStore` and `CryptoStore` errors by deleting previous data and retrying the crypto store opening
+
+##### Changed
+
 ## [v0.1.4] - 02/09/2024
 ##### Added
 - BER-395: Merge upstream MatrixSDK v0.27.13.

--- a/MatrixSDK.podspec
+++ b/MatrixSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MatrixSDK"
-  s.version      = "0.1.4"
+  s.version      = "0.1.5"
   s.summary      = "The iOS SDK to build apps compatible with Matrix (https://www.matrix.org)"
 
   s.description  = <<-DESC


### PR DESCRIPTION
**Context**
- To ensure a smooth login process for the users 

**Relevant issues**
- Closes https://github.com/nedap/berichten-ios/issues/541

**Changes**
> What does it do?
> In summary, what changes are made to the code?
- When opening the crypto store fails with `OpenStore` or `CryptoStore` errors, the app deletes previous data and retries the operation.